### PR TITLE
Feature/save loop

### DIFF
--- a/app/include/config.h
+++ b/app/include/config.h
@@ -14,6 +14,7 @@ const int buttonRecordPin = 3;
 const int buttonStopPin = 4;
 const int buttonPlayPin = 5;
 const int buttonModePin = 41;
+const int buttonSavePin = 40;
 
 // which input on the audio shield will be used?
 const int input = AUDIO_INPUT_MIC;

--- a/app/include/types.hpp
+++ b/app/include/types.hpp
@@ -5,14 +5,11 @@
 
 // Bounce objects to easily and reliably read the buttons
 struct Buttons {
-  /* Bounce left;
-  Bounce nav;
-  Bounce select;
-  Bounce right; */
   Bounce stop;
   Bounce record;
   Bounce play;
   Bounce mode;
+  Bounce save;
 };
 
 #endif

--- a/app/include/utils.hpp
+++ b/app/include/utils.hpp
@@ -1,6 +1,7 @@
 #ifndef UTILS_HPP
 #define UTILS_HPP
 
+#include "types.hpp"
 #include <track.hpp>
 
 void adjustMicLevel();
@@ -12,6 +13,7 @@ void initializeInterface(AudioControlSGTL5000 &interface);
 void initializeSdCard();
 void initializeSerialCommunication();
 void monitorAudioEngine();
+void readButtons(Buttons &buttons);
 void showLevels(AudioAnalyzePeak *peakL, AudioAnalyzePeak *peakR,
                 elapsedMillis *ms, const char *label);
 void showInputLevels(AudioAnalyzePeak *peakL, AudioAnalyzePeak *peakR);

--- a/app/lib/track/include/track.hpp
+++ b/app/lib/track/include/track.hpp
@@ -1,7 +1,9 @@
 #ifndef TRACK_HPP
 #define TRACK_HPP
 
+#include <Arduino.h>
 #include <Audio.h>
+#include <TimeLib.h>
 
 enum class Mode { Replace, Overdub };
 enum class Status { Stop, Record, Play, Pause };
@@ -78,6 +80,7 @@ public:
   void punchIn(Mode mode, float pan);
   void punchOut();
   bool record(Mode mode, float pan);
+  void save();
   bool startPlaying();
   bool startRecording(Mode mode, float pan);
   bool stop(bool cancel = false);

--- a/app/platformio.ini
+++ b/app/platformio.ini
@@ -13,8 +13,6 @@ default_envs = teensy41
 
 [env]
 lib_ldf_mode = chain+
-lib_ignore = 
-	Recorder
 monitor_eol = LF
 
 [env:native]
@@ -24,8 +22,8 @@ platform = native
 board = teensy41
 build_flags =
     -D USB_MIDI_AUDIO_SERIAL
-    ; -D USE_USB_INPUT
-    ; -D USE_USB_OUTPUT
+    ;-D USE_USB_INPUT
+    ;-D USE_USB_OUTPUT
 framework = arduino
 lib_deps = https://github.com/h4yn0nnym0u5e/Audio#feature/buffered-SD
 platform = teensy

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -41,10 +41,9 @@ Mode mode = Mode::Overdub;
 float pan = 0.0;
 
 Buttons buttons = {
-    Bounce(buttonStopPin, 8),
-    Bounce(buttonRecordPin, 8),
-    Bounce(buttonPlayPin, 8),
-    Bounce(buttonModePin, 8),
+    Bounce(buttonStopPin, 8), Bounce(buttonRecordPin, 8),
+    Bounce(buttonPlayPin, 8), Bounce(buttonModePin, 8),
+    Bounce(buttonSavePin, 8),
 };
 
 void setup() {
@@ -70,10 +69,7 @@ void setup() {
 
 void loop() {
   // First, read the buttons
-  buttons.record.update();
-  buttons.stop.update();
-  buttons.play.update();
-  buttons.mode.update();
+  readButtons(buttons);
 
 #ifndef USE_USB_OUTPUT
   adjustVolume(interface);
@@ -84,6 +80,11 @@ void loop() {
   monitorAudioEngine();
 
   // Respond to button presses
+  if (buttons.save.fallingEdge()) {
+    status = Status::Stop;
+    track.save();
+  }
+
   if (buttons.mode.fallingEdge()) {
     if (mode == Mode::Overdub) {
       mode = Mode::Replace;

--- a/app/src/utils.cpp
+++ b/app/src/utils.cpp
@@ -1,4 +1,3 @@
-#include <Arduino.h>
 #include <config.h>
 #include <utils.hpp>
 
@@ -35,6 +34,7 @@ void configureButtons() {
   pinMode(buttonStopPin, INPUT_PULLUP);
   pinMode(buttonPlayPin, INPUT_PULLUP);
   pinMode(buttonModePin, INPUT_PULLUP);
+  pinMode(buttonSavePin, INPUT_PULLUP);
 }
 
 // Find and start the audio shield
@@ -88,7 +88,10 @@ void initializeSdCard() {
 void initializeSerialCommunication() {
   Serial.begin(9600);
 
-  delay(1000);
+  // Wait for Serial Monitor to open
+  while (!Serial)
+    ;
+  delay(100);
   if (CrashReport) {
     Serial.println(CrashReport);
     CrashReport.clear();
@@ -109,6 +112,14 @@ void monitorAudioEngine() {
     Serial.println(")");
     ms = 0;
   }
+}
+
+void readButtons(Buttons &buttons) {
+  buttons.record.update();
+  buttons.stop.update();
+  buttons.play.update();
+  buttons.mode.update();
+  buttons.save.update();
 }
 
 // Read and display stereo input or output channels


### PR DESCRIPTION
## Related Issues:
* [Implement process to write to SD storage](https://app.asana.com/0/1203221076104575/1203349316387103)

## Main Changes:
* Added the ability to save a loop to a WAV file
  * This is saved to the `/loops` directory of the onboard SD card. It is currently saved with the current timestamp.
  * An external button is required, but we may use a touchscreen button in the future.

## Steps To Test:
1. Connect an external button to pin 40.
2. Record a loop.
3. Press the save button, and in the serial monitor, wait until "Saved track to file:", followed by the filename, is logged.
4. Stop the program, turn off the device, then remove the SD card.
5. Insert the SD card into a device with an SD card reader and mount the filesystem.
6. Navigate to the `/loops` subdirectory of the filesystem, and verify that the loop has been successfully written to a file.
7. Verify that the WAV file plays the correct audio.
